### PR TITLE
25 book polymorphic enabling

### DIFF
--- a/limit-orderbook/LimitOrder.cpp
+++ b/limit-orderbook/LimitOrder.cpp
@@ -1,5 +1,5 @@
 #include "Order.h"
 #include "LimitOrder.h"
 
-LimitOrder::LimitOrder(unsigned int _id, unsigned long int _timestamp, unsigned int _quantity, bool _type, double _price) :
-    Order::Order(_id, _timestamp, _quantity, _type), price(_price) {}
+LimitOrder::LimitOrder(unsigned int _id, unsigned long int _timestamp, bool _type, unsigned int _quantity, double _price) :
+    Order::Order(_id, _timestamp, _type, _quantity), price(_price) {}

--- a/limit-orderbook/LimitOrder.h
+++ b/limit-orderbook/LimitOrder.h
@@ -8,7 +8,7 @@ class LimitOrder : public Order {
         double price;
 
     public:
-        LimitOrder(unsigned int _id, unsigned long int _timestamp, unsigned int _quantity, bool _type, double _price);
+        LimitOrder(unsigned int _id, unsigned long int _timestamp,  bool _type, unsigned int _quantity, double _price);
 
         double get_price(){return price;}
 

--- a/limit-orderbook/Makefile
+++ b/limit-orderbook/Makefile
@@ -1,5 +1,5 @@
 CXX = clang++
-CXXFLAGS = -Wall -std=c++17
+CXXFLAGS = -Werror -std=c++17
 TARGET = main.out
 SRC = ./*.cpp
 

--- a/limit-orderbook/Order.cpp
+++ b/limit-orderbook/Order.cpp
@@ -1,4 +1,4 @@
 #include "Order.h"
 
-Order::Order(unsigned int _id, unsigned long int _timestamp, unsigned int _quantity, bool _type)
-    : id(_id), timestamp(_timestamp), quantity(_quantity), type(_type) {}
+Order::Order(unsigned int _id, unsigned long int _timestamp, bool _type, unsigned int _quantity)
+    : id(_id), timestamp(_timestamp), type(_type), quantity(_quantity) {}

--- a/limit-orderbook/Order.h
+++ b/limit-orderbook/Order.h
@@ -11,6 +11,8 @@ class Order{
     public:
         Order(unsigned int _id, unsigned long int _timestamp, unsigned int _quantity, bool _type);
 
+        virtual ~Order() = default;
+
         unsigned int get_id(){return id;}
 
         unsigned long int get_timestamp(){return timestamp;}

--- a/limit-orderbook/Order.h
+++ b/limit-orderbook/Order.h
@@ -5,11 +5,11 @@ class Order{
     private:
         unsigned int id; //NOTE: generate unique IDs?
         unsigned long int timestamp; //NOTE: Unix Epoch?
-        unsigned int quantity;
         bool type; //(0: buy, 1: sell)
+        unsigned int quantity;
 
     public:
-        Order(unsigned int _id, unsigned long int _timestamp, unsigned int _quantity, bool _type);
+        Order(unsigned int _id, unsigned long int _timestamp, bool _type, unsigned int _quantity);
 
         virtual ~Order() = default;
 
@@ -17,9 +17,9 @@ class Order{
 
         unsigned long int get_timestamp(){return timestamp;}
 
-        unsigned int get_quantity(){return quantity;}
-
         bool get_type(){return type;}
+
+        unsigned int get_quantity(){return quantity;}
 
         void set_quantity(unsigned int _quantity){quantity = _quantity;}
 };

--- a/limit-orderbook/OrderBook.cpp
+++ b/limit-orderbook/OrderBook.cpp
@@ -1,11 +1,56 @@
 #include "OrderBook.h"
+#include "Order.h"
+#include "LimitOrder.h"
 
 OrderBook::OrderBook(){
     /*Default map & deque constructors*/
 }
 
 unsigned int OrderBook::submitLimitOrder(unsigned int quantity, bool type, double price){
-    //TODO: Implement. Need to figure out how to construct the Limit Order (unique id & timestamp and where those go?)
-    // Then you need to call the matching function or implement the logic here itself. Figure it out.
+    /*NOTE: (temporary) generate id & timestamp*/
+    unsigned int id = 7;
+    unsigned long int timestamp = 10;
+
+    /*Matching Logic*/
+    if(!type){ //Buy Order
+        
+        auto price_it = ask_book.begin();
+        while(price_it != ask_book.end()) {
+            if(price_it->first > price) break;
+
+            auto& order_queue = price_it->second;
+
+            while(!order_queue.empty()){
+                unsigned int order_quantity = order_queue.front().get_quantity();
+                
+                if(quantity > order_quantity) {
+                    quantity -= order_quantity;
+                    order_queue.pop_front();
+                }
+                else if(quantity < order_quantity) {
+                    order_queue.front().set_quantity(order_quantity - quantity);
+                    return id;
+                }
+                else {
+                    order_queue.pop_front();
+                    if(order_queue.empty()) {
+                        price_it = ask_book.erase(price_it);
+                    }
+                    return id;
+                }
+            }
+
+            /*If queue is empty after loop, erase from ask book*/
+            price_it = ask_book.erase(price_it);
+        }
+
+        /*Residual Limit Order Quantity - insert into bid book*/
+        // deque<Order> not deque<LimitOrder>
+        bid_book[price].emplace_back(id, timestamp, quantity, type, price); //N.B. emplace_back == push_back(Order())
+    }
+
+    // else{ //Sell Order
+        
+    // }
     return 0;
 }

--- a/limit-orderbook/OrderBook.cpp
+++ b/limit-orderbook/OrderBook.cpp
@@ -21,14 +21,14 @@ unsigned int OrderBook::submitLimitOrder(unsigned int quantity, bool type, doubl
             auto& order_queue = price_it->second;
 
             while(!order_queue.empty()){
-                unsigned int order_quantity = order_queue.front().get_quantity();
+                unsigned int order_quantity = order_queue.front()->get_quantity();
                 
                 if(quantity > order_quantity) {
                     quantity -= order_quantity;
                     order_queue.pop_front();
                 }
                 else if(quantity < order_quantity) {
-                    order_queue.front().set_quantity(order_quantity - quantity);
+                    order_queue.front()->set_quantity(order_quantity - quantity);
                     return id;
                 }
                 else {
@@ -46,7 +46,7 @@ unsigned int OrderBook::submitLimitOrder(unsigned int quantity, bool type, doubl
 
         /*Residual Limit Order Quantity - insert into bid book*/
         // deque<Order> not deque<LimitOrder>
-        bid_book[price].emplace_back(id, timestamp, quantity, type, price); //N.B. emplace_back == push_back(Order())
+        bid_book[price].emplace_back(make_shared<LimitOrder>(id, timestamp, quantity, type, price));
     }
 
     // else{ //Sell Order

--- a/limit-orderbook/OrderBook.cpp
+++ b/limit-orderbook/OrderBook.cpp
@@ -6,7 +6,7 @@ OrderBook::OrderBook(){
     /*Default map & deque constructors*/
 }
 
-unsigned int OrderBook::submitLimitOrder(unsigned int quantity, bool type, double price){
+unsigned int OrderBook::submitLimitOrder(bool type, unsigned int quantity, double price){
     /*NOTE: (temporary) generate id & timestamp*/
     unsigned int id = 7;
     unsigned long int timestamp = 10;

--- a/limit-orderbook/OrderBook.h
+++ b/limit-orderbook/OrderBook.h
@@ -18,7 +18,7 @@ class OrderBook {
         OrderBook();
 
         //NOTE: submitLimitOrder(), cancelLimitOrder(id), updateLimitOrder(id, quantity, price), go here as functions
-        unsigned int submitLimitOrder(unsigned int quantity, bool type, double price);
+        unsigned int submitLimitOrder(bool type, unsigned int quantity , double price);
 
         map<double, deque<shared_ptr<Order>>> get_bid_book(){return bid_book;}
 

--- a/limit-orderbook/OrderBook.h
+++ b/limit-orderbook/OrderBook.h
@@ -10,8 +10,8 @@ using namespace std;
 class OrderBook {
     private: //NOTE: Extension plans: if you use a matching engine class, the derivative class needs access to books (protected)
         /*Fields*/
-        map<double, deque<Order>> bid_book;
-        map<double, deque<Order>> ask_book;
+        map<double, deque<shared_ptr<Order>>> bid_book;
+        map<double, deque<shared_ptr<Order>>> ask_book;
         //NOTE: In future, replace with custom trees instead of slow maps here (despite RBT)
     
     public:
@@ -20,9 +20,9 @@ class OrderBook {
         //NOTE: submitLimitOrder(), cancelLimitOrder(id), updateLimitOrder(id, quantity, price), go here as functions
         unsigned int submitLimitOrder(unsigned int quantity, bool type, double price);
 
-        map<double, deque<Order>> get_bid_book(){return bid_book;}
+        map<double, deque<shared_ptr<Order>>> get_bid_book(){return bid_book;}
 
-        map<double, deque<Order>> get_ask_book(){return ask_book;}
+        map<double, deque<shared_ptr<Order>>> get_ask_book(){return ask_book;}
 };
 
 #endif

--- a/limit-orderbook/main.cpp
+++ b/limit-orderbook/main.cpp
@@ -12,13 +12,13 @@ int main(){
     double price = 105;
     unsigned int quantity = 4;
 
-    book.submitLimitOrder(quantity, 0, price); //0: buy
+    book.submitLimitOrder(0, quantity, price); //0: buy
     cout << "Order Quantity: " << book.get_bid_book()[price].front()->get_quantity() << endl;
     cout << "Order Price: $" << dynamic_pointer_cast<LimitOrder>(book.get_bid_book()[price].front())->get_price() << endl;
 
     price = 200;
     quantity = 50;
-    book.submitLimitOrder(quantity, 0, price); //0: buy
+    book.submitLimitOrder(0, quantity, price); //0: buy
     cout << "Order Quantity: " << book.get_bid_book()[price].front()->get_quantity() << endl;
     cout << "Order Price: $" << dynamic_pointer_cast<LimitOrder>(book.get_bid_book()[price].front())->get_price() << endl;
 

--- a/limit-orderbook/main.cpp
+++ b/limit-orderbook/main.cpp
@@ -2,9 +2,25 @@
 #include <string>
 
 #include "OrderBook.h"
+#include "Order.h"
+#include "LimitOrder.h"
 using namespace std;
 
 int main(){
-    cout << "Its ALIVEE" << endl;
+    //cout << "Its ALIVEE" << endl;
+    OrderBook book = OrderBook();
+    double price = 105;
+    unsigned int quantity = 4;
+
+    book.submitLimitOrder(quantity, 0, price); //0: buy
+    cout << "Order Quantity: " << book.get_bid_book()[price].front()->get_quantity() << endl;
+    cout << "Order Price: $" << dynamic_pointer_cast<LimitOrder>(book.get_bid_book()[price].front())->get_price() << endl;
+
+    price = 200;
+    quantity = 50;
+    book.submitLimitOrder(quantity, 0, price); //0: buy
+    cout << "Order Quantity: " << book.get_bid_book()[price].front()->get_quantity() << endl;
+    cout << "Order Price: $" << dynamic_pointer_cast<LimitOrder>(book.get_bid_book()[price].front())->get_price() << endl;
+
     return 0;
 }


### PR DESCRIPTION
1) Changed `deque<Order>` to `deque<shared_ptr<Order>>` to allow for polymorphism. Enabling storage of `shared_ptr<LimitOrder>` within the container. 

2) Re-ordered parameters (swapped quantity and type such that `type`, `quantity`) for ease of use.

3) Changed MakeFile `-Wall` to `-Werror` for stricter code compliance.
